### PR TITLE
Run api requests in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "clap",
+ "futures",
  "prometheus-client",
  "reqwest",
  "serde",
@@ -204,12 +205,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -217,6 +233,12 @@ name = "futures-core"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-sink"
@@ -237,6 +259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { version = "4", default-features = false, features = ["std", "derive", "env", "color", "usage", "help"] }
 axum = { version = "0.6", default-features = false, features = ["http1", "tokio"] }
 tokio = { version = "1.25", default-features = false, features = ["macros", "rt"] }
+futures = { version = "0.3", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "multipart", "json"] }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
This doesn't help much as we mostly wait on lifetime metric from `/production.json`. It doesn't hurt and maybe it will be more useful with more metrics, so let's keep it.

On the graph below 18:23 is when parallel requests started:

<img width="1426" alt="image" src="https://user-images.githubusercontent.com/89186/218329945-c9342043-0bc4-4238-ab29-3eb41766b96b.png">

On the graph below 17:54 is when `/production.json` was added:

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/89186/218330004-da79be63-2b02-478c-b62e-d5bf24bbf965.png">
